### PR TITLE
Deployment fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Note: The VM desktop resolution can be changed at "Preferences->LXQt Settings->M
 
     //Then, install inspired in editable mode
 
-    `pip install -e . --no-deps`
+    `pip install -e . `
 
 4. To download the latest DFT database and ML models from Zenodo and extract the files, go to (create) a folder where you want to keep these files, run:
    

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -36,8 +36,10 @@ requirements:
 
   run:
     - python
+    - pymace
     - qtpy
-    - pyqt==5  
+    - pyqt==5.*
+    - pyg
     - pytorch
     - phonopy
     - pandas

--- a/src/inspired/inspired.py
+++ b/src/inspired/inspired.py
@@ -19,6 +19,7 @@ from ase.io import read
 from ase.formula import Formula
 from ase.spacegroup import get_spacegroup
 from ase.visualize import view
+from inspired.version import __version__ 
 
 class INSPIRED(QMainWindow):
     def __init__(self, parent=None):
@@ -423,6 +424,7 @@ if __name__ == "__main__":
     print('********************************************************************************************************')
     print('* Inelastic Neutron Scattering Prediction for Instantaneous Results and Experimental Design (INSPIRED) *')
     print('********************************************************************************************************')
+    print(f'INFO: version {__version__}')
     print('INFO: Initializing ...')
     app = QApplication(sys.argv)
     main_window = INSPIRED()
@@ -439,10 +441,18 @@ def gui():
     """
     Main entry point for Qt application
     """
+    
+    input_flags = sys.argv[1::]
+    if "--v" in input_flags or "--version" in input_flags:
+        print(__version__)
+        sys.exit()
+    
     print('********************************************************************************************************')
     print('* Inelastic Neutron Scattering Prediction for Instantaneous Results and Experimental Design (INSPIRED) *')
     print('********************************************************************************************************')
+    print(f'INFO: version {__version__}')
     print('INFO: Initializing ...')
+
     app = QApplication(sys.argv)
     main_window = INSPIRED()
     print('INFO: Starting GUI ...')

--- a/src/inspired/inspired.py
+++ b/src/inspired/inspired.py
@@ -441,18 +441,17 @@ def gui():
     """
     Main entry point for Qt application
     """
-    
+    #print version and exit
     input_flags = sys.argv[1::]
     if "--v" in input_flags or "--version" in input_flags:
         print(__version__)
         sys.exit()
-    
+    #start the app
     print('********************************************************************************************************')
     print('* Inelastic Neutron Scattering Prediction for Instantaneous Results and Experimental Design (INSPIRED) *')
     print('********************************************************************************************************')
     print(f'INFO: version {__version__}')
     print('INFO: Initializing ...')
-
     app = QApplication(sys.argv)
     main_window = INSPIRED()
     print('INFO: Starting GUI ...')

--- a/src/inspired/version.py
+++ b/src/inspired/version.py
@@ -1,6 +1,6 @@
 """Module to load the version created by versioningit
 
-Will fall back to a default it shiver is not installed"""
+Will fall back to a default if inspired is not installed"""
 
 try:
     from ._version import __version__

--- a/src/inspired/version.py
+++ b/src/inspired/version.py
@@ -1,0 +1,8 @@
+"""Module to load the version created by versioningit
+
+Will fall back to a default it shiver is not installed"""
+
+try:
+    from ._version import __version__
+except ModuleNotFoundError:
+    __version__ = "0.0.1"


### PR DESCRIPTION
# Short description of the changes:
This includes changes related to conda package dependency resolution and printing the version wirth --version or --v flags and README updates.

# Long description of the changes:
This includes changes related to 
- conda package dependency resolution by testing the rc conda package
- print the version with --version or --v flags; code is based on shiver
- README installation updates. no pip dependencies are specified anymore, the related flag is removed.

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

To test:
1. install inspired locally with conda package process:
- python -m build --wheel --no-isolation
- check-wheel-contents dist/inspired-*.whl
- cd conda.recipe/
- echo "versioningit $(versioningit ../)"
- CHANNELS="--channel conda-forge --channel pytorch --channel pyg"
- VERSION=$(versioningit ../) conda mambabuild $CHANNELS --output-folder . .
- conda verify noarch/inspired-*.tar.bz2
- conda install < noarch/inspired-*.tar.bz2>

2. install inspired in editable mode:
pip install -e .

3. in an environment where inspired is installed run:
- inspired (it should work as before). the (dynamic) version is printed
- inspired --version  . It should print the current version (tag format)
- inspired --v    . It should print the current version (tag format)

# References
[[Story] Deployment of INSPIRED](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/7313)
