### PR TITLE
Github action fetch flags added

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,7 +18,6 @@ jobs:
           uses: actions/checkout@v4
           with:
             fetch-tags: true
-            fetch-depth: 0
         - name: Micromamba    
           uses: mamba-org/setup-micromamba@v1
           with:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -17,6 +17,7 @@ jobs:
         - uses: actions/checkout@v4
         - uses: mamba-org/setup-micromamba@v1
           with:
+            fetch-tags: true
             environment-file: environment.yml
             cache-environment-key: ${{ runner.os }}-env-${{ hashFiles('**/environment.yml') }}
             cache-downloads-key: ${{ runner.os }}-downloads-${{ hashFiles('**/environment.yml') }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -17,7 +17,7 @@ jobs:
         - name: Checkout
           uses: actions/checkout@v4
           with:
-            fetch-tags: true
+            fetch-depth: 0
         - name: Micromamba    
           uses: mamba-org/setup-micromamba@v1
           with:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -19,6 +19,7 @@ jobs:
           with:
             fetch-depth: 100
             fetch-tags: true
+            ref: ${{ github.ref }}
         - name: Micromamba    
           uses: mamba-org/setup-micromamba@v1
           with:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,11 +14,14 @@ jobs:
         run:
           shell: bash -l {0}
       steps:
-        - uses: actions/checkout@v4
-        - uses: mamba-org/setup-micromamba@v1
+        - name: Checkout
+          uses: actions/checkout@v4
           with:
             fetch-tags: true
             fetch-depth: 0
+        - name: Micromamba    
+          uses: mamba-org/setup-micromamba@v1
+          with:
             environment-file: environment.yml
             cache-environment-key: ${{ runner.os }}-env-${{ hashFiles('**/environment.yml') }}
             cache-downloads-key: ${{ runner.os }}-downloads-${{ hashFiles('**/environment.yml') }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,6 +18,7 @@ jobs:
         - uses: mamba-org/setup-micromamba@v1
           with:
             fetch-tags: true
+            fetch-depth: 0
             environment-file: environment.yml
             cache-environment-key: ${{ runner.os }}-env-${{ hashFiles('**/environment.yml') }}
             cache-downloads-key: ${{ runner.os }}-downloads-${{ hashFiles('**/environment.yml') }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -17,7 +17,8 @@ jobs:
         - name: Checkout
           uses: actions/checkout@v4
           with:
-            fetch-depth: 0
+            fetch-depth: 100
+            fetch-tags: true
         - name: Micromamba    
           uses: mamba-org/setup-micromamba@v1
           with:


### PR DESCRIPTION
# Short description of the changes:
<!-- Add a concise description here-->
The flags are added in actions/checkout@v4 explicitly, so that the github actions can fetch tags.
versiongingit recognizes the tag (for untagged commits) and calculates the next dev version properly on the githu runners.

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
